### PR TITLE
Load flash_tool into path if build succeeded

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-export CFLAGS="$CFLAGS -I/opt/homebrew/Cellar/argp-standalone/1.3/include/"
-export LDFLAGS="$LDFLAGS -L/opt/homebrew/Cellar/argp-standalone/1.3/lib/ -largp"
+ARG_PATH=$(brew --cellar argp-standalone)
+ARG_VERSION=$(brew list --versions argp-standalone | tr ' ' '\n' | tail -1)
+
+export CFLAGS="$CFLAGS -I$ARG_PATH/$ARG_VERSION/include/"
+export LDFLAGS="$LDFLAGS -L$ARG_PATH/$ARG_VERSION/lib/ -largp"
 
 if [ -d build ]; then
     rm -rf build
@@ -12,3 +15,9 @@ cd build
 
 meson ..
 ninja
+
+if [ $? -eq 0 ]; then
+  mv flash_tool/flash_tool /usr/local/bin
+  rm -rf ../build
+  echo "\nTo enable flash_tool on your current terminal, run:\n  \`source ~/.zshrc\`\n"
+fi


### PR DESCRIPTION
Hello,

If the build succeeds, it would be useful to load the binary into the path automatically.

Also, this takes into consideration if the `Cellar` directory is located on another path (or if the `argp` version used is different).

For example, mine was located at `/usr/local/Cellar/` instead of `/opt/homebrew/Cellar/`.

✌🏼 